### PR TITLE
Updating Contribute An Idea button + adding disclaimer comments to AI relevant files

### DIFF
--- a/src/lib/constants/config.ts
+++ b/src/lib/constants/config.ts
@@ -1,7 +1,7 @@
 export const APP_CONFIG = {
   ITEMS_PER_PAGE: 4,
   CONTRIBUTE_URL:
-    'https://github.com/web3privacy/docs/blob/main/src/content/docs/projects/hackathon-use-cases-generator.md',
+    'https://docs.web3privacy.info/projects/privacy-idea-generator',
   LOGO_URL: 'https://web3privacy.info/logo.svg',
   DATA_ENDPOINTS: {
     COMMUNITY: '/data/ideas/community-ideas.json',

--- a/src/lib/constants/config.ts
+++ b/src/lib/constants/config.ts
@@ -1,7 +1,6 @@
 export const APP_CONFIG = {
   ITEMS_PER_PAGE: 4,
-  CONTRIBUTE_URL:
-    'https://docs.web3privacy.info/projects/privacy-idea-generator',
+  CONTRIBUTE_URL: 'https://docs.web3privacy.info/projects/privacy-idea-generator',
   LOGO_URL: 'https://web3privacy.info/logo.svg',
   DATA_ENDPOINTS: {
     COMMUNITY: '/data/ideas/community-ideas.json',

--- a/src/pages/api/ai.ts
+++ b/src/pages/api/ai.ts
@@ -1,3 +1,7 @@
+// Experimental feature: AI integration for the idea generation - for more information see: https://github.com/web3privacy/privacy-idea-generator/issues/3
+// note: requires user to have either a commercial AI token or their own local one running as well as own deployment of the webapp
+// the front-end deployed at ideas.web3privacy.info will not provide AI integration or offer free token for requests
+
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 interface AIIdeaRequest {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,4 +1,8 @@
-// Additional types for the AI API if you want to be more specific about the response
+// Experimental feature: AI integration for the idea generation - for more information see: https://github.com/web3privacy/privacy-idea-generator/issues/3
+// note: requires user to have either a commercial AI token or their own local one running as well as own deployment of the webapp
+// the front-end deployed at ideas.web3privacy.info will not provide AI integration or offer free token for requests
+
+// Below are additional types for the AI API if you want to be more specific about the response - see src/pages/api/ai.ts for more details.
 export interface AIIdeaResponse {
   name: string
   description: string


### PR DESCRIPTION
Changed url of the button to point to https://docs.web3privacy.info/projects/privacy-idea-generator instead of https://github.com/web3privacy/docs/blob/main/src/content/docs/projects/hackathon-use-cases-generator.md

Added the following comments in the code as a disclaimer at top of two files:

```
// Experimental feature: AI integration for the idea generation - for more information see: https://github.com/web3privacy/privacy-idea-generator/issues/3
// note: requires user to have either a commercial AI token or their own local one running as well as own deployment of the webapp
// the front-end deployed at ideas.web3privacy.info will not provide AI integration or offer free token for requests
```